### PR TITLE
feature/foss-gapps

### DIFF
--- a/installer/01-setup_lxd.sh
+++ b/installer/01-setup_lxd.sh
@@ -3,7 +3,7 @@
 CYAN='\e[1;36m'
 RESET='\e[0m'
 
-REPO_URL='https://github.com/supechicken/ChromeOS-Waydroid-Installer/raw/refs/heads/main'
+REPO_URL='https://github.com/neilgfoster/cros-waydroid-installer/raw/refs/heads/main'
 
 # Simplify colors and print errors to stderr (2).
 echo_error() { echo -e "\e[1;91m${*}${RESET}" >&2; } # Use Light Red for errors.

--- a/installer/02-setup_waydroid.sh
+++ b/installer/02-setup_waydroid.sh
@@ -3,17 +3,7 @@
 CYAN='\e[1;36m'
 RESET='\e[0m'
 
-REPO_URL='https://github.com/supechicken/ChromeOS-Waydroid-Installer/raw/refs/heads/main'
-
-ANDROID13_TV_IMG_X86=(
-  https://github.com/supechicken/waydroid-androidtv-build/releases/download/20250327/lineage-20.0-20250327-UNOFFICIAL-WaydroidATV_x86_64.zip
-  44d77c229f4737dfca6e360cdc06a6a2860717b504038b11b0216ed8a51f6a5a
-)
-
-ANDROID13_TV_IMG_ARM=(
-  https://github.com/supechicken/waydroid-androidtv-build/releases/download/20250225/lineage-20.0-20250226-UNOFFICIAL-WaydroidATV_arm64.zip
-  4ac4cc286ac3c0238735bbb4efad9b45c94ef80a93e3195c1e5f77a19216efd5
-)
+REPO_URL='https://github.com/neilgfoster/cros-waydroid-installer/raw/refs/heads/main'
 
 # Simplify colors and print errors to stderr (2).
 echo_error() { echo -e "\e[1;91m${*}${RESET}" >&2; } # Use Light Red for errors.
@@ -58,7 +48,8 @@ cat <<EOT
 Select an Android version to install:
 
   1. Android 13
-  2. Android 13 TV
+  2. Android 13 FOSS
+  3. Android 13 GAPPS
 
 EOT
 
@@ -75,37 +66,12 @@ case "${ANDROID_VERSION}" in
   sudo waydroid init -s VANILLA
 ;;
 2)
-  ANDROID_VERSION='Android 13 TV'
-  case "$(uname -m)" in
-  arm*|aarch64)
-    ANDROID_IMG_URL="${ANDROID13_TV_IMG_ARM[0]}"
-    ANDROID_IMG_SHA="${ANDROID13_TV_IMG_ARM[1]}"
-  ;;
-  x86_64)
-    ANDROID_IMG_URL="${ANDROID13_TV_IMG_X86[0]}"
-    ANDROID_IMG_SHA="${ANDROID13_TV_IMG_X86[1]}"
-  ;;
-  esac
-
-  echo_info "[+] Installing ${CYAN}${ANDROID_VERSION}${RESET}"
-
-  sudo mkdir -p /etc/waydroid-extra/images
-  cd /etc/waydroid-extra/images
-
-  if [ ! -f android13.zip ]; then
-    echo_info '[+] Downloading Android 13 image...'
-    sudo curl -L "${ANDROID_IMG_URL}" -o android13.zip
-  fi
-
-  echo_info '[+] Verifying archive...'
-  sha256sum -c - <<< "${ANDROID_IMG_SHA} android13.zip"
-
-  echo_info '[+] Decompressing Android 13 image...'
-  sudo unzip android13.zip
-  sudo rm android13.zip
-
-  echo_info '[+] Initializing system...'
-  sudo waydroid init -f
+  echo_info "[+] Installing ${CYAN}Android 13 FOSS${RESET}"
+  sudo waydroid init -s FOSS
+;;
+3)
+  echo_info "[+] Installing ${CYAN}Android 13 GAPPS${RESET}"
+  sudo waydroid init -s GAPPS
 ;;
 esac
 

--- a/scripts/start-waydroid
+++ b/scripts/start-waydroid
@@ -36,7 +36,7 @@ sommelier --direct-scale -X bash -eu <<'EOF'
   cage -- bash -c '
     exec 2>&1
     cage-fullscreen $(xwininfo -display $ORIGDISP -name "wlroots - X11-1" | grep -m1 -o "0x[0-9]\+")
-    waydroid show-full-ui -q
+    waydroid -q show-full-ui
   ' 2> /dev/null
 EOF
 ) &

--- a/scripts/start-waydroid
+++ b/scripts/start-waydroid
@@ -28,13 +28,15 @@ fi
 waydroid session stop
 
 # start waydroid with cage
-exec sommelier --direct-scale -X bash -eu <<'EOF'
+(
+sommelier --direct-scale -X bash -eu <<'EOF'
   export ORIGDISP=$DISPLAY
   unset WAYLAND_DISPLAY
 
   cage -- bash -c '
     exec 2>&1
     cage-fullscreen $(xwininfo -display $ORIGDISP -name "wlroots - X11-1" | grep -m1 -o "0x[0-9]\+")
-    waydroid show-full-ui
+    waydroid show-full-ui -q
   ' 2> /dev/null
 EOF
+) &

--- a/scripts/start-waydroid
+++ b/scripts/start-waydroid
@@ -28,8 +28,7 @@ fi
 waydroid session stop
 
 # start waydroid with cage
-(
-sommelier --direct-scale -X bash -eu <<'EOF'
+exec sommelier --direct-scale -X bash -eu <<'EOF'
   export ORIGDISP=$DISPLAY
   unset WAYLAND_DISPLAY
 
@@ -39,4 +38,4 @@ sommelier --direct-scale -X bash -eu <<'EOF'
     waydroid -q show-full-ui
   ' 2> /dev/null
 EOF
-) &
+&

--- a/scripts/start-waydroid
+++ b/scripts/start-waydroid
@@ -28,6 +28,7 @@ fi
 waydroid session stop
 
 # start waydroid with cage
+(
 sommelier --direct-scale -X bash -eu <<'EOF'
   export ORIGDISP=$DISPLAY
   unset WAYLAND_DISPLAY
@@ -38,4 +39,4 @@ sommelier --direct-scale -X bash -eu <<'EOF'
     waydroid -q show-full-ui
   ' 2> /dev/null
 EOF
-&
+) &

--- a/scripts/start-waydroid
+++ b/scripts/start-waydroid
@@ -28,7 +28,7 @@ fi
 waydroid session stop
 
 # start waydroid with cage
-exec sommelier --direct-scale -X bash -eu <<'EOF'
+sommelier --direct-scale -X bash -eu <<'EOF'
   export ORIGDISP=$DISPLAY
   unset WAYLAND_DISPLAY
 


### PR DESCRIPTION
This pull request updates the installer scripts to use new repository URLs and changes the Android image selection options to simplify installation and maintenance. The most notable changes are the removal of custom TV image handling and the introduction of "FOSS" and "GAPPS" variants for Android 13, as well as improvements to the Waydroid startup script.

Repository and image source updates:
* Changed `REPO_URL` in both `01-setup_lxd.sh` and `02-setup_waydroid.sh` to point to `neilgfoster/cros-waydroid-installer` instead of `supechicken/ChromeOS-Waydroid-Installer`. [[1]](diffhunk://#diff-aee675db1b06b107e1c3046a5334d3dbf3dda886b71814aa60dc8cf3823e33f4L6-R6) [[2]](diffhunk://#diff-674704d8cca5d128a434b5e97180f0d0d7864ec2307d610b1bd93d367be21d2aL6-R6)
* Removed hardcoded URLs and SHA256 hashes for custom Android 13 TV images, eliminating manual image download and verification steps. [[1]](diffhunk://#diff-674704d8cca5d128a434b5e97180f0d0d7864ec2307d610b1bd93d367be21d2aL6-R6) [[2]](diffhunk://#diff-674704d8cca5d128a434b5e97180f0d0d7864ec2307d610b1bd93d367be21d2aL78-R74)

Installer UX and logic changes:
* Updated the installer prompt to offer "Android 13 FOSS" and "Android 13 GAPPS" options instead of "Android 13 TV".
* Simplified the installation logic: selecting FOSS or GAPPS now directly calls `waydroid init -s FOSS` or `waydroid init -s GAPPS`, removing the need for manual image management.

Waydroid startup improvements:
* Modified the `start-waydroid` script to run the Sommelier/X11/cage session in a background subshell, and added the `-q` flag to `waydroid show-full-ui` for quieter output.